### PR TITLE
Link week 6 source code as "stable" version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5.
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5, so you may need to make a few manual changes.
 - [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release (Week 6) is known to be stable for all platforms.
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTM5
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5.
 - [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release (Week 6) is known to be stable for all platforms.
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 6.
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7.
+- [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release is known to be stable for all platforms, but it does not contain any of the things the Week 7 update has
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 
   - [Psych Engine Docs](https://github.com/ShadowMario/FNF-PsychEngine/wiki) - Psych Engine modding documentation (sorta outdated).

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5, so you may need to make a few manual changes if nessasery.
-- [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release (Week 6) is known to be stable for all platforms.
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 
   - [Psych Engine Docs](https://github.com/ShadowMario/FNF-PsychEngine/wiki) - Psych Engine modding documentation (sorta outdated).

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7.
-- [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release is known to be stable for all platforms, but it does not contain any of the things the Week 7 update has
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTM5
+- [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release (Week 6) is known to be stable for all platforms.
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 
   - [Psych Engine Docs](https://github.com/ShadowMario/FNF-PsychEngine/wiki) - Psych Engine modding documentation (sorta outdated).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Unsure what to contribute? Check out the `good first issue` [tagged Github issue
 
 
 ## Programming
-- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5, so you may need to make a few manual changes.
+- [Friday Night Funkin' Official Source Code](https://github.com/FunkinCrew/funkin) - The original open source game by The Funkin' Crew. Last updated for Week 7, one problem is that this version is a little unstable if you aren't compiling for HTML5, so you may need to make a few manual changes if nessasery.
 - [Friday Night Funkin' Official Source Code (Stable)](https://github.com/FunkinCrew/Funkin/tree/a083938ac803a91fbb15f03e432dea620f8a3b4a) - This release (Week 6) is known to be stable for all platforms.
 ### Engines and Forks
 - [Psych Engine](https://github.com/ShadowMario/FNF-PsychEngine) - A fork of base game which includes new quality-of-life changes, performance improvements, and Lua-based mod tools. Popular and well-documented. 


### PR DESCRIPTION
Corrects "Last updated for Week 6" to "Last updated for Week 7", while also linking the Week 6 source code as the stable version