### PR TITLE
Prevent Blank Lines From Showing up in Summary

### DIFF
--- a/scripts/summary-script/index.js
+++ b/scripts/summary-script/index.js
@@ -138,6 +138,7 @@ const delay = time => new Promise(res => setTimeout(res, time));
       console.log("");
       output.push(`- [PR #${pull.number}, "${pull.title}" by ${pull.user.login}](${pull.html_url}) merged at ${pull.merged_at}, added:\n`);
       for (let block of linesAdded) {
+        block = block.filter(v => v.trim().length > 0); // exclude blank lines from appearing as empty list items
         output.push(`  - ${block.length} line${block.length == 1 ? "" : "s"}:\n`)
         for (let line of block) {
           // try to remove any indents and bullet points


### PR DESCRIPTION
Whenever any contributors' commits contain blank lines in them, it shows up as an empty bullet point in the summary that gets generated. This pr should exclude such blank lines.
Basically, this pr should fix stuff like this:
![screenie](https://user-images.githubusercontent.com/83609901/222119584-7478f342-ed99-49f5-b839-b4c99b856c83.png)
